### PR TITLE
Add Prisma with SQLite schema and seeding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL="file:./dev.db"

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.MD
+++ b/README.MD
@@ -57,7 +57,11 @@ npm install
 yarn
 ```
 
-### 3. Run the mock API server
+### 3. Configure environment variables
+
+Copy `.env.example` to `.env` and ensure `DATABASE_URL="file:./dev.db"` is set.
+
+### 4. Run the mock API server
 
 ```bash
 yarn serve:api (for yarn users)
@@ -66,7 +70,7 @@ yarn serve:api (for yarn users)
 npm serve:api (for npm users)
 ```
 
-### 4. Start the frontend app
+### 5. Start the frontend app
 
 ```bash
 npm run dev (for npm users)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "serve:api": "json-server --watch db.json --port 3003",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "prisma:migrate": "prisma migrate dev --name init",
+    "prisma:seed": "prisma db seed --preview-feature"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",
@@ -25,7 +27,8 @@
     "recharts": "^3.1.0",
     "sonner": "^2.0.6",
     "zod": "^4.0.5",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "@prisma/client": "^5.12.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",
@@ -37,6 +40,7 @@
     "eslint-config-next": "15.3.5",
     "json-server": "^1.0.0-beta.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "prisma": "^5.12.1"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,33 @@
+ datasource db {
+   provider = "sqlite"
+   url      = env("DATABASE_URL")
+ }
+ 
+ generator client {
+   provider = "prisma-client-js"
+ }
+ 
+ model User {
+   id           Int            @id
+   name         String
+   email        String         @unique
+   role         String
+   password     String
+   tasks        Task[]
+   notifications Notification[]
+ }
+ 
+ model Task {
+   id         String @id
+   title      String
+   assignedTo Int
+   status     String
+   user       User   @relation(fields: [assignedTo], references: [id])
+ }
+ 
+ model Notification {
+   id      Int    @id
+   userId  Int
+   message String
+   user    User   @relation(fields: [userId], references: [id])
+ }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,48 @@
+import { PrismaClient } from '@prisma/client'
+import data from '../db.json'
+
+const prisma = new PrismaClient()
+
+async function main() {
+  for (const user of data.users) {
+    await prisma.user.create({
+      data: {
+        id: parseInt(user.id, 10),
+        name: user.name,
+        email: user.email,
+        role: user.role,
+        password: user.password,
+      },
+    })
+  }
+
+  for (const task of data.tasks) {
+    await prisma.task.create({
+      data: {
+        id: task.id,
+        title: task.title,
+        assignedTo: task.assignedTo,
+        status: task.status,
+      },
+    })
+  }
+
+  for (const note of data.notifications) {
+    await prisma.notification.create({
+      data: {
+        id: parseInt(note.id, 10),
+        userId: note.userId,
+        message: note.message,
+      },
+    })
+  }
+}
+
+main()
+  .catch((e) => {
+    console.error(e)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })


### PR DESCRIPTION
## Summary
- set up Prisma with SQLite and add initial schema
- seed database using sample JSON data
- document environment variable usage
- add example `.env` and npm scripts for Prisma

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a442db8c88329841b24d4fe3281b2