### PR TITLE
Implement Prisma API routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.yarnrc.yml

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,25 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model User {
+  id       Int    @id @default(autoincrement())
+  name     String
+  email    String @unique
+  role     String
+  password String?
+  tasks    Task[]
+}
+
+model Task {
+  id         Int    @id @default(autoincrement())
+  title      String
+  assignedTo Int
+  status     String
+  user       User   @relation(fields: [assignedTo], references: [id])
+}

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  try {
+    const task = await prisma.task.findUnique({ where: { id } });
+    if (!task) {
+      return NextResponse.json({ error: 'Task not found' }, { status: 404 });
+    }
+    return NextResponse.json(task, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to fetch task' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  const data = await request.json();
+  try {
+    const task = await prisma.task.update({ where: { id }, data });
+    return NextResponse.json(task, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to update task' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  try {
+    await prisma.task.delete({ where: { id } });
+    return NextResponse.json({ message: 'Task deleted' }, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to delete task' }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET() {
+  try {
+    const tasks = await prisma.task.findMany();
+    return NextResponse.json(tasks, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to fetch tasks' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const data = await request.json();
+    const task = await prisma.task.create({ data });
+    return NextResponse.json(task, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to create task' }, { status: 500 });
+  }
+}

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  const data = await request.json();
+  try {
+    const user = await prisma.user.update({ where: { id }, data });
+    return NextResponse.json(user, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to update user' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const id = Number(params.id);
+  try {
+    await prisma.user.delete({ where: { id } });
+    return NextResponse.json({ message: 'User deleted' }, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to delete user' }, { status: 500 });
+  }
+}

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const email = searchParams.get('email') ?? undefined;
+
+  try {
+    const users = await prisma.user.findMany({ where: { email } });
+    return NextResponse.json(users, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to fetch users' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const data = await request.json();
+    const user = await prisma.user.create({ data });
+    return NextResponse.json(user, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to create user' }, { status: 500 });
+  }
+}

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = global as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({ log: ['query', 'error', 'warn'] });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+
+export default prisma;


### PR DESCRIPTION
## Summary
- add Prisma schema and client helper
- create user CRUD API endpoints
- create task CRUD API endpoints

## Testing
- `yarn lint`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688a442ecd388329ac8485cb4212eba5