### PR TITLE
Update API base path

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ export default function LoginForm() {
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const res = await fetch(`http://localhost:3003/users?email=${email}`);
+    const res = await fetch(`/api/users?email=${email}`);
     const users = await res.json();
 
     if (users.length === 0) {

--- a/src/lib/api/fetcher.ts
+++ b/src/lib/api/fetcher.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-const API_BASE_URL = 'http://localhost:3003';
+const API_BASE_URL = '/api';
 
 export const fetcher = axios.create({
     baseURL: API_BASE_URL,


### PR DESCRIPTION
## Summary
- switch axios baseURL to `/api`
- update login screen to use the new endpoint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688a47107c848329891eefb5fcf1a98e