### PR TITLE
feat: add password hashing and secure login

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dayjs": "^1.11.13",
     "framer-motion": "^12.23.5",
     "lucide-react": "^0.525.0",
+    "bcrypt": "^5.1.1",
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 // prisma/seed.ts
 import { PrismaClient } from '@prisma/client';
+import bcrypt from 'bcrypt';
 
 const prisma = new PrismaClient();
 
@@ -27,17 +28,32 @@ async function main() {
     prisma.user.upsert({
       where: { email: 'alice@example.com' },
       update: {},
-      create: { name: 'Alice', email: 'alice@example.com', role: 'admin', password: 'password123' },
+      create: {
+        name: 'Alice',
+        email: 'alice@example.com',
+        role: 'admin',
+        password: await bcrypt.hash('password123', 10),
+      },
     }),
     prisma.user.upsert({
       where: { email: 'bob@example.com' },
       update: {},
-      create: { name: 'Bob', email: 'bob@example.com', role: 'manager', password: 'password123' },
+      create: {
+        name: 'Bob',
+        email: 'bob@example.com',
+        role: 'manager',
+        password: await bcrypt.hash('password123', 10),
+      },
     }),
     prisma.user.upsert({
       where: { email: 'charlie@example.com' },
       update: {},
-      create: { name: 'Charlie', email: 'charlie@example.com', role: 'user', password: 'password123' },
+      create: {
+        name: 'Charlie',
+        email: 'charlie@example.com',
+        role: 'user',
+        password: await bcrypt.hash('password123', 10),
+      },
     }),
   ]);
 
@@ -49,7 +65,7 @@ async function main() {
           name: generateRandomName(i + 4),
           email: generateEmail(i + 4),
           role: generateRole(),
-          password: 'password123',
+          password: await bcrypt.hash('password123', 10),
         },
       })
     )

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,13 +1,27 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import bcrypt from 'bcrypt';
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id: idParam } = await params;
   const id = Number(idParam);
   const data = await request.json();
 
+  if (data.password) {
+    data.password = await bcrypt.hash(data.password, 10);
+  }
+
   try {
-    const user = await prisma.user.update({ where: { id }, data });
+    const user = await prisma.user.update({
+      where: { id },
+      data,
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+      },
+    });
     return NextResponse.json(user, { status: 200 });
   } catch (err) {
     console.error(err);

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import bcrypt from 'bcrypt';
+
+export async function POST(request: Request) {
+  try {
+    const { email, password } = await request.json();
+
+    if (!email || !password) {
+      return NextResponse.json(
+        { error: 'Email and password are required' },
+        { status: 400 }
+      );
+    }
+
+    const user = await prisma.user.findUnique({ where: { email } });
+
+    if (!user || !user.password) {
+      return NextResponse.json(
+        { error: 'Invalid credentials' },
+        { status: 401 }
+      );
+    }
+
+    const isValid = await bcrypt.compare(password, user.password);
+
+    if (!isValid) {
+      return NextResponse.json(
+        { error: 'Invalid credentials' },
+        { status: 401 }
+      );
+    }
+
+    const { password: _pw, ...safeUser } = user;
+
+    return NextResponse.json(safeUser, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: 'Failed to login' },
+      { status: 500 }
+    );
+  }
+}
+

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import bcrypt from 'bcrypt';
 
 const ROLES = ['admin', 'manager', 'user'] as const;
 // type Role = typeof ROLES[number];
@@ -11,6 +12,12 @@ export async function GET(request: Request) {
   try {
     const users = await prisma.user.findMany({
       where: email ? { email } : undefined,
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+      },
     });
 
     return NextResponse.json(users, { status: 200 });
@@ -44,12 +51,20 @@ export async function POST(request: Request) {
       );
     }
 
+    const hashedPassword = password ? await bcrypt.hash(password, 10) : undefined;
+
     const user = await prisma.user.create({
       data: {
         name,
         email,
         role,
-        password, // optional
+        password: hashedPassword, // optional
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
       },
     });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,19 +13,18 @@ export default function LoginForm() {
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    const res = await fetch(`/api/users?email=${email}`);
-    const users = await res.json();
+    const res = await fetch('/api/users/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password }),
+    });
 
-    if (users.length === 0) {
+    if (!res.ok) {
       setError('Invalid credentials');
       return;
     }
 
-    const user = users[0];
-    if (user.password !== password) {
-      setError('Invalid credentials');
-      return;
-    }
+    const user = await res.json();
 
     useAuthStore.getState().login(user);
 

--- a/src/lib/store/useAuthStore.ts
+++ b/src/lib/store/useAuthStore.ts
@@ -7,7 +7,6 @@ interface User {
   name: string;
   email: string;
   role: Role;
-  password?: string;
 }
 
 interface AuthState {


### PR DESCRIPTION
## Summary
- hash user passwords with bcrypt before storing and omit them from all API responses
- add server-side login endpoint that validates passwords using bcrypt.compare
- migrate seed data and auth store to support hashed credentials

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6890bb16cc148329b8c44b44a8ec1d79