### PR TITLE
feat: add organization sign-up flow

### DIFF
--- a/prisma/migrations/20250804151819_add_organization/migration.sql
+++ b/prisma/migrations/20250804151819_add_organization/migration.sql
@@ -1,0 +1,32 @@
+/*
+  Warnings:
+
+  - Added the required column `organizationId` to the `User` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateTable
+CREATE TABLE "Organization" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "sector" TEXT NOT NULL,
+    "phone" TEXT
+);
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "password" TEXT,
+    "organizationId" INTEGER NOT NULL,
+    CONSTRAINT "User_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_User" ("email", "id", "name", "password", "role") SELECT "email", "id", "name", "password", "role" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,14 +7,26 @@ datasource db {
   provider = "sqlite"
   url      = env("DATABASE_URL")
 }
-model User {
-  id       Int    @id @default(autoincrement())
-  name     String
-  email    String @unique
-  role     String
-  password String?
-  tasks    Task[]
+
+model Organization {
+  id    Int    @id @default(autoincrement())
+  name  String
+  sector String
+  phone String?
+  users User[]
 }
+
+model User {
+  id             Int    @id @default(autoincrement())
+  name           String
+  email          String @unique
+  role           String
+  password       String?
+  organizationId Int
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  tasks          Task[]
+}
+
 model Task {
   id         Int    @id @default(autoincrement())
   title      String

--- a/src/app/api/auth/register/route.ts
+++ b/src/app/api/auth/register/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+
+export async function POST(request: Request) {
+  try {
+    const {
+      userName,
+      organizationName,
+      sector,
+      email = '',
+      phone,
+      password = '',
+    } = await request.json();
+
+    const normalisedEmail = email.trim().toLowerCase();
+
+    if (!userName || !organizationName || !sector || !normalisedEmail || !password) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      );
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10);
+
+    const organization = await prisma.organization.create({
+      data: {
+        name: organizationName,
+        sector,
+        phone,
+      },
+    });
+
+    const user = await prisma.user.create({
+      data: {
+        name: userName,
+        email: normalisedEmail,
+        role: 'admin',
+        password: hashedPassword,
+        organizationId: organization.id,
+      },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+        organizationId: true,
+      },
+    });
+
+    const token = jwt.sign(
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        organizationId: user.organizationId,
+      },
+      process.env.JWT_SECRET!,
+      { expiresIn: '1h' }
+    );
+
+    return NextResponse.json({ user, token }, { status: 201 });
+  } catch (err) {
+    console.error('REGISTER_ERROR', err);
+    return NextResponse.json(
+      { error: 'Failed to register' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -20,6 +20,7 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
         name: true,
         email: true,
         role: true,
+        organizationId: true,
       },
     });
     return NextResponse.json(user, { status: 200 });

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -13,7 +13,10 @@ export async function POST(request: Request) {
       );
     }
 
-    const user = await prisma.user.findUnique({ where: { email } });
+    const user = await prisma.user.findUnique({
+      where: { email },
+      select: { id: true, name: true, email: true, role: true, password: true, organizationId: true },
+    });
 
     if (!user || !user.password) {
       return NextResponse.json(
@@ -31,7 +34,8 @@ export async function POST(request: Request) {
       );
     }
 
-    const { password: _pw, ...safeUser } = user;
+    const { password: passwordHash, ...safeUser } = user;
+    void passwordHash;
 
     return NextResponse.json(safeUser, { status: 200 });
   } catch (err) {

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -8,15 +8,22 @@ const ROLES = ['admin', 'manager', 'user'] as const;
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
   const email = searchParams.get('email') ?? undefined;
+  const organizationId = searchParams.get('organizationId')
+    ? Number(searchParams.get('organizationId'))
+    : undefined;
 
   try {
     const users = await prisma.user.findMany({
-      where: email ? { email } : undefined,
+      where: {
+        ...(email ? { email } : {}),
+        ...(organizationId ? { organizationId } : {}),
+      },
       select: {
         id: true,
         name: true,
         email: true,
         role: true,
+        organizationId: true,
       },
     });
 
@@ -35,11 +42,11 @@ export async function POST(request: Request) {
     const data = await request.json();
 
     // Basic validation
-    const { name, email, role, password } = data;
+    const { name, email, role, password, organizationId } = data;
 
-    if (!name || !email || !role) {
+    if (!name || !email || !role || !organizationId) {
       return NextResponse.json(
-        { error: 'Name, email, and role are required' },
+        { error: 'Name, email, role, and organizationId are required' },
         { status: 400 }
       );
     }
@@ -59,12 +66,14 @@ export async function POST(request: Request) {
         email,
         role,
         password: hashedPassword, // optional
+        organizationId,
       },
       select: {
         id: true,
         name: true,
         email: true,
         role: true,
+        organizationId: true,
       },
     });
 

--- a/src/lib/hooks/useLogin.ts
+++ b/src/lib/hooks/useLogin.ts
@@ -3,10 +3,11 @@ import { useAuthStore } from '@/lib/store/useAuthStore';
 import type { Role } from '@/lib/store/useAuthStore';
 
 interface User {
-  id: string;
+  id: number;
   name: string;
   email: string;
   role: Role;
+  organizationId: number;
 }
 
 interface LoginResponse {

--- a/src/lib/store/useAuthStore.ts
+++ b/src/lib/store/useAuthStore.ts
@@ -3,10 +3,11 @@ import { create } from 'zustand';
 export type Role = 'admin' | 'manager' | 'user';
 
 interface User {
-  id: string;
+  id: number;
   name: string;
   email: string;
   role: Role;
+  organizationId: number;
 }
 
 interface AuthState {


### PR DESCRIPTION
## Summary
- add Organization model and registration endpoint
- tie users and login to organization
- update user APIs and auth store for organization awareness

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build` (fails: Failed to fetch `Lato` from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_6890ce57d8c883299c07832085bc5581