### PR TITLE
Restrict tasks API to organization scope

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,9 +1,18 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 
-export async function GET() {
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const organizationId = searchParams.get('organizationId')
+    ? Number(searchParams.get('organizationId'))
+    : undefined;
+
   try {
-    const tasks = await prisma.task.findMany();
+    const tasks = await prisma.task.findMany({
+      where: {
+        ...(organizationId ? { user: { organizationId } } : {}),
+      },
+    });
     return NextResponse.json(tasks, { status: 200 });
   } catch (err) {
     console.error(err);

--- a/src/lib/hooks/useTasks.ts
+++ b/src/lib/hooks/useTasks.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetcher } from '../api/fetcher';
+import { useAuthStore } from '@/lib/store/useAuthStore';
 
 export interface Task {
   id: number;
@@ -9,12 +10,16 @@ export interface Task {
 }
 
 export const useTasks = () => {
+  const organizationId = useAuthStore((s) => s.user?.organizationId);
   return useQuery<Task[]>({
-    queryKey: ['tasks'],
+    queryKey: ['tasks', organizationId],
     queryFn: async () => {
-      const response = await fetcher.get('/tasks');
+      const response = await fetcher.get('/tasks', {
+        params: { organizationId },
+      });
       return response.data;
     },
+    enabled: !!organizationId,
   });
 };
 


### PR DESCRIPTION
## Summary
- filter GET /tasks by organization using a query parameter
- scope task fetching hooks to the current user's organization

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689508198f9483298008d3523a552cfd