### PR TITLE
feat: extend prisma schema with profiles and task metadata

### DIFF
--- a/prisma/migrations/20250813090147_add_profile_attachment_activitylog/migration.sql
+++ b/prisma/migrations/20250813090147_add_profile_attachment_activitylog/migration.sql
@@ -1,0 +1,103 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'MANAGER', 'USER');
+
+-- CreateEnum
+CREATE TYPE "TaskStatus" AS ENUM ('PENDING', 'IN_PROGRESS', 'COMPLETED');
+
+-- CreateEnum
+CREATE TYPE "TaskPriority" AS ENUM ('LOW', 'MEDIUM', 'HIGH');
+
+-- CreateTable
+CREATE TABLE "Organization" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "sector" TEXT NOT NULL,
+    "phone" TEXT,
+
+    CONSTRAINT "Organization_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'USER',
+    "password" TEXT,
+    "organizationId" TEXT NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Task" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "organizationId" TEXT NOT NULL,
+    "assigneeId" TEXT,
+    "createdById" TEXT NOT NULL,
+    "status" "TaskStatus" NOT NULL DEFAULT 'PENDING',
+    "priority" "TaskPriority" NOT NULL DEFAULT 'MEDIUM',
+
+    CONSTRAINT "Task_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Profile" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "bio" TEXT,
+
+    CONSTRAINT "Profile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ActivityLog" (
+    "id" TEXT NOT NULL,
+    "taskId" TEXT NOT NULL,
+    "userId" TEXT,
+    "action" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ActivityLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Profile_userId_key" ON "Profile"("userId");
+
+-- AddForeignKey
+ALTER TABLE "User" ADD CONSTRAINT "User_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_organizationId_fkey" FOREIGN KEY ("organizationId") REFERENCES "Organization"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_assigneeId_fkey" FOREIGN KEY ("assigneeId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Task" ADD CONSTRAINT "Task_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Profile" ADD CONSTRAINT "Profile_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityLog" ADD CONSTRAINT "ActivityLog_taskId_fkey" FOREIGN KEY ("taskId") REFERENCES "Task"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityLog" ADD CONSTRAINT "ActivityLog_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,4 +1,3 @@
-
 generator client {
   provider = "prisma-client-js"
 }
@@ -8,29 +7,83 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum Role {
+  ADMIN
+  MANAGER
+  USER
+}
+
+enum TaskStatus {
+  PENDING
+  IN_PROGRESS
+  COMPLETED
+}
+
+enum TaskPriority {
+  LOW
+  MEDIUM
+  HIGH
+}
+
 model Organization {
-  id    Int    @id @default(autoincrement())
+  id    String @id @default(cuid())
   name  String
   sector String
   phone String?
   users User[]
+  tasks Task[]
 }
 
 model User {
-  id             Int    @id @default(autoincrement())
-  name           String
-  email          String @unique
-  role           String
-  password       String?
-  organizationId Int
-  organization   Organization @relation(fields: [organizationId], references: [id])
-  tasks          Task[]
+  id           String @id @default(cuid())
+  name         String
+  email        String @unique
+  role         Role   @default(USER)
+  password     String?
+  organizationId String
+  organization Organization @relation(fields: [organizationId], references: [id])
+  assignedTasks Task[] @relation("AssignedTasks")
+  createdTasks  Task[] @relation("CreatedTasks")
+  profile       Profile?
+  activityLogs  ActivityLog[]
 }
 
 model Task {
-  id         Int    @id @default(autoincrement())
-  title      String
-  assignedTo Int
-  status     String
-  user       User   @relation(fields: [assignedTo], references: [id])
+  id             String @id @default(cuid())
+  title          String
+  organizationId String
+  organization   Organization @relation(fields: [organizationId], references: [id])
+  assigneeId     String?
+  assignee       User? @relation("AssignedTasks", fields: [assigneeId], references: [id])
+  createdById    String
+  createdBy      User   @relation("CreatedTasks", fields: [createdById], references: [id])
+  status         TaskStatus @default(PENDING)
+  priority       TaskPriority @default(MEDIUM)
+  attachments    Attachment[]
+  activityLogs   ActivityLog[]
 }
+
+model Profile {
+  id     String @id @default(cuid())
+  userId String @unique
+  bio    String?
+  user   User   @relation(fields: [userId], references: [id])
+}
+
+model Attachment {
+  id     String @id @default(cuid())
+  taskId String
+  url    String
+  task   Task   @relation(fields: [taskId], references: [id])
+}
+
+model ActivityLog {
+  id        String   @id @default(cuid())
+  taskId    String
+  userId    String?
+  action    String
+  createdAt DateTime @default(now())
+  task      Task     @relation(fields: [taskId], references: [id])
+  user      User?    @relation(fields: [userId], references: [id])
+}
+

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,20 +1,8 @@
 // prisma/seed.ts
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Role } from '@prisma/client';
 import bcrypt from 'bcrypt';
 
 const prisma = new PrismaClient();
-
-const randomInt = (min: number, max: number) =>
-  Math.floor(Math.random() * (max - min + 1)) + min;
-
-const generateRandomName = (i: number) => `User${i}`;
-const generateEmail = (i: number) => `user${i}@example.com`;
-const generateRole = () =>
-  (Math.random() > 0.5 ? 'manager' : 'user') as 'manager' | 'user';
-const generateStatus = () => {
-  const statuses = ['pending', 'in-progress', 'completed'];
-  return statuses[randomInt(0, statuses.length - 1)];
-};
 
 async function main() {
   if (process.env.NODE_ENV === 'production') {
@@ -24,84 +12,59 @@ async function main() {
 
   console.log('🌱 Starting seed...');
 
-  // Step 0: Ensure a demo organization exists
+  await prisma.activityLog.deleteMany();
+  await prisma.attachment.deleteMany();
+  await prisma.task.deleteMany();
+  await prisma.profile.deleteMany();
+  await prisma.user.deleteMany();
   await prisma.organization.deleteMany();
-  const organization = await prisma.organization.create({
-    data: {
-      name: 'Demo Org',
-      sector: 'General',
-      phone: '1234567890',
-    },
+
+  const adminOrg = await prisma.organization.create({
+    data: { name: 'Admin Org', sector: 'General', phone: '1111111111' }
   });
 
-  // Step 1: Base users (Admin, Manager, User)
-  const baseUsers = await Promise.all([
-    prisma.user.upsert({
-      where: { email: 'alice@example.com' },
-      update: {},
-      create: {
-        name: 'Alice',
-        email: 'alice@example.com',
-        role: 'admin',
-        password: await bcrypt.hash('password123', 10),
-        organization: { connect: { id: organization.id } },
-      },
-    }),
-    prisma.user.upsert({
-      where: { email: 'bob@example.com' },
-      update: {},
-      create: {
-        name: 'Bob',
-        email: 'bob@example.com',
-        role: 'manager',
-        password: await bcrypt.hash('password123', 10),
-        organization: { connect: { id: organization.id } },
-      },
-    }),
-    prisma.user.upsert({
-      where: { email: 'charlie@example.com' },
-      update: {},
-      create: {
-        name: 'Charlie',
-        email: 'charlie@example.com',
-        role: 'user',
-        password: await bcrypt.hash('password123', 10),
-        organization: { connect: { id: organization.id } },
-      },
-    }),
-  ]);
+  const managerOrg = await prisma.organization.create({
+    data: { name: 'Manager Org', sector: 'General', phone: '2222222222' }
+  });
 
-  // Step 2: Add 50 more users (random manager/user, no admins)
-  const extraUsers = await Promise.all(
-    Array.from({ length: 50 }).map(async (_, i) =>
-      prisma.user.create({
-        data: {
-          name: generateRandomName(i + 4),
-          email: generateEmail(i + 4),
-          role: generateRole(),
-          password: await bcrypt.hash('password123', 10),
-          organization: { connect: { id: organization.id } },
-        },
-      })
-    )
-  );
+  const userOrg = await prisma.organization.create({
+    data: { name: 'User Org', sector: 'General', phone: '3333333333' }
+  });
 
-  const allUsers = [...baseUsers, ...extraUsers];
+  await prisma.user.create({
+    data: {
+      name: 'Alice',
+      email: 'alice@example.com',
+      role: Role.ADMIN,
+      password: await bcrypt.hash('password123', 10),
+      organization: { connect: { id: adminOrg.id } },
+      profile: { create: { bio: 'Admin user' } }
+    }
+  });
 
-  // Step 3: Wipe tasks before seeding
-  await prisma.task.deleteMany();
+  await prisma.user.create({
+    data: {
+      name: 'Bob',
+      email: 'bob@example.com',
+      role: Role.MANAGER,
+      password: await bcrypt.hash('password123', 10),
+      organization: { connect: { id: managerOrg.id } },
+      profile: { create: { bio: 'Manager user' } }
+    }
+  });
 
-  // Step 4: Add 35+ tasks assigned to random users
-  const totalTasks = 35;
-  const taskData = Array.from({ length: totalTasks }).map((_, i) => ({
-    title: `Task ${i + 1}`,
-    status: generateStatus(),
-    assignedTo: allUsers[randomInt(0, allUsers.length - 1)].id,
-  }));
+  await prisma.user.create({
+    data: {
+      name: 'Charlie',
+      email: 'charlie@example.com',
+      role: Role.USER,
+      password: await bcrypt.hash('password123', 10),
+      organization: { connect: { id: userOrg.id } },
+      profile: { create: { bio: 'Regular user' } }
+    }
+  });
 
-  await prisma.task.createMany({ data: taskData });
-
-  console.log(`✅ Seed complete. Added ${allUsers.length} users and ${totalTasks} tasks.`);
+  console.log('✅ Seed complete. Added admin, manager and user.');
 }
 
 main()
@@ -112,3 +75,4 @@ main()
   .finally(async () => {
     await prisma.$disconnect();
   });
+


### PR DESCRIPTION
## Summary
- add Role, TaskStatus, and TaskPriority enums
- introduce Profile, Attachment, and ActivityLog models
- seed admin, manager, and user organizations

## Testing
- `npx prisma generate`
- `npx prisma migrate dev` *(fails: Can't reach database server at `localhost:5432`)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c53c0a1dc8329933a6046caf1aee5