### PR TITLE
Add authentication middleware and restrict user/task access

### DIFF
--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,32 +1,50 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { withAuth, AuthRequest } from '@/middleware/withAuth';
 
-export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const organizationId = searchParams.get('organizationId')
-    ? Number(searchParams.get('organizationId'))
-    : undefined;
-
+export const GET = withAuth(async (request: AuthRequest) => {
   try {
-    const tasks = await prisma.task.findMany({
-      where: {
-        ...(organizationId ? { user: { organizationId } } : {}),
-      },
-    });
+    const { user } = request;
+    const where =
+      user.role === 'user'
+        ? { userId: user.id }
+        : { user: { organizationId: user.organizationId } };
+    const tasks = await prisma.task.findMany({ where });
     return NextResponse.json(tasks, { status: 200 });
   } catch (err) {
     console.error(err);
     return NextResponse.json({ error: 'Failed to fetch tasks' }, { status: 500 });
   }
-}
+});
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (request: AuthRequest) => {
   try {
     const data = await request.json();
+    const { user } = request;
+
+    if (user.role === 'user') {
+      data.userId = user.id;
+    } else {
+      if (!data.userId) {
+        return NextResponse.json(
+          { error: 'userId is required' },
+          { status: 400 }
+        );
+      }
+      const targetUser = await prisma.user.findUnique({
+        where: { id: data.userId },
+        select: { organizationId: true },
+      });
+      if (!targetUser || targetUser.organizationId !== user.organizationId) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+    }
+
     const task = await prisma.task.create({ data });
     return NextResponse.json(task, { status: 201 });
   } catch (err) {
     console.error(err);
     return NextResponse.json({ error: 'Failed to create task' }, { status: 500 });
   }
-}
+});
+

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,22 +1,19 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
+import { withAuth, AuthRequest } from '@/middleware/withAuth';
 
 const ROLES = ['admin', 'manager', 'user'] as const;
-// type Role = typeof ROLES[number];
 
-export async function GET(request: Request) {
+export const GET = withAuth(async (request: AuthRequest) => {
   const { searchParams } = new URL(request.url);
   const email = searchParams.get('email') ?? undefined;
-  const organizationId = searchParams.get('organizationId')
-    ? Number(searchParams.get('organizationId'))
-    : undefined;
 
   try {
     const users = await prisma.user.findMany({
       where: {
         ...(email ? { email } : {}),
-        ...(organizationId ? { organizationId } : {}),
+        organizationId: request.user.organizationId,
       },
       select: {
         id: true,
@@ -35,9 +32,9 @@ export async function GET(request: Request) {
       { status: 500 }
     );
   }
-}
+}, { roles: ['admin', 'manager'] });
 
-export async function POST(request: Request) {
+export const POST = withAuth(async (request: AuthRequest) => {
   try {
     const data = await request.json();
 
@@ -56,6 +53,10 @@ export async function POST(request: Request) {
         { error: `Role must be one of: ${ROLES.join(', ')}` },
         { status: 400 }
       );
+    }
+
+    if (organizationId !== request.user.organizationId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 
     const hashedPassword = password ? await bcrypt.hash(password, 10) : undefined;
@@ -85,4 +86,5 @@ export async function POST(request: Request) {
       { status: 500 }
     );
   }
-}
+}, { roles: ['admin'] });
+

--- a/src/middleware/withAuth.ts
+++ b/src/middleware/withAuth.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import jwt from 'jsonwebtoken';
+import prisma from '@/lib/prisma';
+
+export type Role = 'admin' | 'manager' | 'user';
+
+interface AuthUser {
+  id: number;
+  role: Role;
+  organizationId: number;
+}
+
+export interface AuthRequest extends Request {
+  user: AuthUser;
+}
+
+interface Options {
+  roles?: Role[];
+}
+
+export function withAuth(
+  handler: (req: AuthRequest, ...args: unknown[]) => Promise<Response>,
+  options: Options = {}
+) {
+  return async (req: Request, ...args: unknown[]) => {
+    const authHeader = req.headers.get('authorization') || '';
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : null;
+    if (!token) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    try {
+      const jwtSecret = process.env.JWT_SECRET;
+      if (!jwtSecret) {
+        throw new Error('JWT secret not configured');
+      }
+      const payload = jwt.verify(token, jwtSecret) as { id: number };
+      const user = await prisma.user.findUnique({
+        where: { id: payload.id },
+        select: { id: true, role: true, organizationId: true },
+      });
+      if (!user) {
+        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+      }
+
+      if (options.roles && !options.roles.includes(user.role as Role)) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+
+      // Enforce organizationId scope if provided in query
+      const url = new URL(req.url);
+      const orgParam = url.searchParams.get('organizationId');
+      if (orgParam && Number(orgParam) !== user.organizationId) {
+        return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+      }
+
+      (req as AuthRequest).user = user as AuthUser;
+      return handler(req as AuthRequest, ...args);
+    } catch (err) {
+      console.error('AUTH_ERROR', err);
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+  };
+}
+


### PR DESCRIPTION
## Summary
- add withAuth middleware to validate JWTs, load users, and enforce role/organization scope
- secure task routes so users manage only their own tasks
- secure user routes to block managers from creating users and restrict queries to the same organization

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c53c0dce8832991e9056e084a0761