### PR TITLE
Validate API input with Zod

### DIFF
--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,12 +1,34 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import prisma from '@/lib/prisma';
 
-export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+const idSchema = z.coerce.number().int();
+
+const updateTaskSchema = z
+  .object({
+    title: z.string().optional(),
+    assignedTo: z.number().int().optional(),
+    status: z.string().optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const { id: idParam } = await params;
-  const id = Number(idParam);
-  
+  const id = idSchema.safeParse(idParam);
+  if (!id.success) {
+    return NextResponse.json(
+      { error: id.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
   try {
-    const task = await prisma.task.findUnique({ where: { id } });
+    const task = await prisma.task.findUnique({ where: { id: id.data } });
     if (!task) {
       return NextResponse.json({ error: 'Task not found' }, { status: 404 });
     }
@@ -17,13 +39,29 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
   }
 }
 
-export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const { id: idParam } = await params;
-  const id = Number(idParam);
-  const data = await request.json();
-  
+  const id = idSchema.safeParse(idParam);
+  if (!id.success) {
+    return NextResponse.json(
+      { error: id.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
+  const data = updateTaskSchema.safeParse(await request.json());
+  if (!data.success) {
+    return NextResponse.json(
+      { error: data.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
   try {
-    const task = await prisma.task.update({ where: { id }, data });
+    const task = await prisma.task.update({ where: { id: id.data }, data: data.data });
     return NextResponse.json(task, { status: 200 });
   } catch (err) {
     console.error(err);
@@ -31,12 +69,21 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
   }
 }
 
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const { id: idParam } = await params;
-  const id = Number(idParam);
-  
+  const id = idSchema.safeParse(idParam);
+  if (!id.success) {
+    return NextResponse.json(
+      { error: id.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
   try {
-    await prisma.task.delete({ where: { id } });
+    await prisma.task.delete({ where: { id: id.data } });
     return NextResponse.json({ message: 'Task deleted' }, { status: 200 });
   } catch (err) {
     console.error(err);

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,11 +1,29 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 import prisma from '@/lib/prisma';
 
+const getTasksQuerySchema = z.object({
+  organizationId: z.coerce.number().int().optional(),
+});
+
+const createTaskSchema = z.object({
+  title: z.string(),
+  assignedTo: z.number().int(),
+  status: z.string(),
+});
+
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const organizationId = searchParams.get('organizationId')
-    ? Number(searchParams.get('organizationId'))
-    : undefined;
+  const query = getTasksQuerySchema.safeParse(
+    Object.fromEntries(new URL(request.url).searchParams)
+  );
+  if (!query.success) {
+    return NextResponse.json(
+      { error: query.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
+  const { organizationId } = query.data;
 
   try {
     const tasks = await prisma.task.findMany({
@@ -21,9 +39,16 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
+  const body = createTaskSchema.safeParse(await request.json());
+  if (!body.success) {
+    return NextResponse.json(
+      { error: body.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
   try {
-    const data = await request.json();
-    const task = await prisma.task.create({ data });
+    const task = await prisma.task.create({ data: body.data });
     return NextResponse.json(task, { status: 201 });
   } catch (err) {
     console.error(err);

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,19 +1,61 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
+import { z } from 'zod';
 
-export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+const ROLES = ['admin', 'manager', 'user'] as const;
+
+const idSchema = z.coerce.number().int();
+
+const updateUserSchema = z
+  .object({
+    name: z.string().optional(),
+    email: z.string().email().optional(),
+    role: z.enum(ROLES).optional(),
+    password: z.string().optional(),
+    organizationId: z.number().int().optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const { id: idParam } = await params;
-  const id = Number(idParam);
-  const data = await request.json();
+  const id = idSchema.safeParse(idParam);
+  if (!id.success) {
+    return NextResponse.json(
+      { error: id.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
 
+  const body = updateUserSchema.safeParse(await request.json());
+  if (!body.success) {
+    return NextResponse.json(
+      { error: body.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
+  const currentUserRole = request.headers.get('x-user-role');
+  if (body.data.role && currentUserRole !== 'admin') {
+    return NextResponse.json(
+      { error: 'Only admins can change roles' },
+      { status: 403 }
+    );
+  }
+
+  const data: z.infer<typeof updateUserSchema> = { ...body.data };
   if (data.password) {
     data.password = await bcrypt.hash(data.password, 10);
   }
 
   try {
     const user = await prisma.user.update({
-      where: { id },
+      where: { id: id.data },
       data,
       select: {
         id: true,
@@ -30,12 +72,21 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
   }
 }
 
-export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
   const { id: idParam } = await params;
-  const id = Number(idParam);
+  const id = idSchema.safeParse(idParam);
+  if (!id.success) {
+    return NextResponse.json(
+      { error: id.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
 
   try {
-    await prisma.user.delete({ where: { id } });
+    await prisma.user.delete({ where: { id: id.data } });
     return NextResponse.json({ message: 'User deleted' }, { status: 200 });
   } catch (err) {
     console.error(err);

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,17 +1,24 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
+import { z } from 'zod';
+
+const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string(),
+});
 
 export async function POST(request: Request) {
   try {
-    const { email, password } = await request.json();
-
-    if (!email || !password) {
+    const parsed = loginSchema.safeParse(await request.json());
+    if (!parsed.success) {
       return NextResponse.json(
-        { error: 'Email and password are required' },
+        { error: parsed.error.issues.map((i) => i.message).join(', ') },
         { status: 400 }
       );
     }
+
+    const { email, password } = parsed.data;
 
     const user = await prisma.user.findUnique({
       where: { email },

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,16 +1,36 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
+import { z } from 'zod';
 
 const ROLES = ['admin', 'manager', 'user'] as const;
 // type Role = typeof ROLES[number];
 
+const userQuerySchema = z.object({
+  email: z.string().email().optional(),
+  organizationId: z.coerce.number().int().optional(),
+});
+
+const createUserSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  role: z.enum(ROLES),
+  password: z.string().optional(),
+  organizationId: z.number().int(),
+});
+
 export async function GET(request: Request) {
-  const { searchParams } = new URL(request.url);
-  const email = searchParams.get('email') ?? undefined;
-  const organizationId = searchParams.get('organizationId')
-    ? Number(searchParams.get('organizationId'))
-    : undefined;
+  const parsed = userQuerySchema.safeParse(
+    Object.fromEntries(new URL(request.url).searchParams)
+  );
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
+  const { email, organizationId } = parsed.data;
 
   try {
     const users = await prisma.user.findMany({
@@ -38,26 +58,17 @@ export async function GET(request: Request) {
 }
 
 export async function POST(request: Request) {
+  const body = createUserSchema.safeParse(await request.json());
+  if (!body.success) {
+    return NextResponse.json(
+      { error: body.error.issues.map((i) => i.message).join(', ') },
+      { status: 400 }
+    );
+  }
+
+  const { name, email, role, password, organizationId } = body.data;
+
   try {
-    const data = await request.json();
-
-    // Basic validation
-    const { name, email, role, password, organizationId } = data;
-
-    if (!name || !email || !role || !organizationId) {
-      return NextResponse.json(
-        { error: 'Name, email, role, and organizationId are required' },
-        { status: 400 }
-      );
-    }
-
-    if (!ROLES.includes(role)) {
-      return NextResponse.json(
-        { error: `Role must be one of: ${ROLES.join(', ')}` },
-        { status: 400 }
-      );
-    }
-
     const hashedPassword = password ? await bcrypt.hash(password, 10) : undefined;
 
     const user = await prisma.user.create({


### PR DESCRIPTION
## Summary
- add Zod validation for task and user API routes
- enforce descriptive error responses for bad input
- restrict role updates to admin users

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c53c216a48329a54037f91d3aad84