### PR TITLE
refactor: add validated auth forms

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,21 +4,39 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useLogin } from '@/lib/hooks/useLogin';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@/lib/zodResolver';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { PasswordStrength } from '@/components/ui/password-strength';
+import { motion } from 'framer-motion';
+import { EyeIcon, EyeOffIcon } from 'lucide-react';
+
+const loginSchema = z.object({
+  email: z.string().email('Invalid email'),
+  password: z.string().min(1, 'Password is required'),
+});
+
+type LoginValues = z.infer<typeof loginSchema>;
 
 export default function LoginForm() {
   const router = useRouter();
   const { login } = useLogin();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
+  const [serverError, setServerError] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [capsLock, setCapsLock] = useState(false);
 
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
+  const form = useForm<LoginValues>({
+    resolver: zodResolver(loginSchema),
+    defaultValues: { email: '', password: '' },
+  });
+
+  const handleSubmit = async (values: LoginValues) => {
+    setServerError('');
     try {
-      const { user } = await login(email, password);
-
+      const { user } = await login(values.email, values.password);
       if (user.role === 'admin') {
         router.push('/admin');
       } else if (user.role === 'manager') {
@@ -27,46 +45,98 @@ export default function LoginForm() {
         router.push('/dashboard');
       }
     } catch {
-      setError('Invalid credentials');
-      setLoading(false);
+      setServerError('Invalid credentials');
     }
   };
 
+  const handleCaps = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    setCapsLock(e.getModifierState('CapsLock'));
+  };
+
+  const password = form.watch('password');
 
   return (
-    <form onSubmit={handleLogin} className="max-w-sm mx-auto mt-10 space-y-4">
-      <h2 className="text-2xl font-semibold">Login</h2>
-      <input
-        type="email"
-        className="w-full px-4 py-2 border rounded"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        required
-      />
-      <input
-        type="password"
-        className="w-full px-4 py-2 border rounded"
-        placeholder="Password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        required
-      />
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      <button
-        type="submit"
-        className="bg-primary text-white w-full py-2 rounded hover:bg-primary/90"
-      >
-        {
-          loading ? 'Logging in...' : 'Log In'
-        }
-      </button>
-      <p className="text-sm text-center">
-        Don&apos;t have an account?{' '}
-        <Link href="/register" className="text-primary hover:underline">
-          Sign up
-        </Link>
-      </p>
-    </form>
+    <div className="grid min-h-screen grid-cols-1 md:grid-cols-2">
+      <div className="hidden md:flex items-center justify-center bg-gray-50">
+        <motion.h2
+          initial={{ opacity: 0, x: -20 }}
+          animate={{ opacity: 1, x: 0 }}
+          className="text-3xl font-semibold"
+        >
+          Welcome Back
+        </motion.h2>
+      </div>
+      <div className="flex items-center justify-center p-8">
+        <form
+          onSubmit={form.handleSubmit(handleSubmit)}
+          className="w-full max-w-md space-y-4"
+          noValidate
+        >
+          <div>
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" autoComplete="email" {...form.register('email')} />
+            {form.formState.errors.email && (
+              <p className="mt-1 text-sm text-red-600" role="alert">
+                {form.formState.errors.email.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="password">Password</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                autoComplete="current-password"
+                {...form.register('password')}
+                onKeyUp={handleCaps}
+                onKeyDown={handleCaps}
+                aria-describedby="caps-lock password-strength"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((p) => !p)}
+                className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-600 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? (
+                  <EyeOffIcon className="h-4 w-4" />
+                ) : (
+                  <EyeIcon className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+            {capsLock && (
+              <p id="caps-lock" className="mt-1 text-xs text-yellow-600" role="alert">
+                Caps lock is on
+              </p>
+            )}
+            <PasswordStrength password={password} />
+            {form.formState.errors.password && (
+              <p className="mt-1 text-sm text-red-600" role="alert">
+                {form.formState.errors.password.message}
+              </p>
+            )}
+          </div>
+          {serverError && (
+            <p className="text-sm text-red-600" role="alert">
+              {serverError}
+            </p>
+          )}
+          <Button type="submit" className="w-full">
+            {form.formState.isSubmitting ? 'Logging in...' : 'Log In'}
+          </Button>
+          <p className="text-sm text-center">
+            Don&apos;t have an account?{' '}
+            <Link
+              href="/register"
+              className="text-primary underline-offset-4 hover:underline"
+            >
+              Sign up
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
   );
 }

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -4,30 +4,56 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useRegister } from '@/lib/hooks/useRegister';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@/lib/zodResolver';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { PasswordStrength } from '@/components/ui/password-strength';
+import { motion } from 'framer-motion';
+import { EyeIcon, EyeOffIcon } from 'lucide-react';
+
+const registerSchema = z.object({
+  userName: z.string().min(1, 'Name is required'),
+  organizationName: z.string().min(1, 'Organization is required'),
+  sector: z.string().min(1, 'Sector is required'),
+  email: z.string().email('Invalid email'),
+  phone: z.string().optional(),
+  password: z.string().min(8, 'Password must be at least 8 characters'),
+});
+
+type RegisterValues = z.infer<typeof registerSchema>;
 
 export default function RegisterForm() {
   const router = useRouter();
-  const { register } = useRegister();
-  const [userName, setUserName] = useState('');
-  const [organizationName, setOrganizationName] = useState('');
-  const [sector, setSector] = useState('');
-  const [email, setEmail] = useState('');
-  const [phone, setPhone] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
+  const { register: registerUser } = useRegister();
+  const [serverError, setServerError] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [capsLock, setCapsLock] = useState(false);
 
-  const handleRegister = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setLoading(true);
+  const form = useForm<RegisterValues>({
+    resolver: zodResolver(registerSchema),
+    defaultValues: {
+      userName: '',
+      organizationName: '',
+      sector: '',
+      email: '',
+      phone: '',
+      password: '',
+    },
+  });
+
+  const handleSubmit = async (values: RegisterValues) => {
+    setServerError('');
     try {
-      const { user } = await register(
-        userName,
-        organizationName,
-        sector,
-        email,
-        phone,
-        password,
+      const { user } = await registerUser(
+        values.userName,
+        values.organizationName,
+        values.sector,
+        values.email,
+        values.phone,
+        values.password,
       );
 
       if (user.role === 'admin') {
@@ -38,74 +64,131 @@ export default function RegisterForm() {
         router.push('/dashboard');
       }
     } catch {
-      setError('Registration failed');
-      setLoading(false);
+      setServerError('Registration failed');
     }
   };
 
+  const handleCaps = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    setCapsLock(e.getModifierState('CapsLock'));
+  };
+
+  const password = form.watch('password');
+
   return (
-    <form onSubmit={handleRegister} className="max-w-sm mx-auto mt-10 space-y-4">
-      <h2 className="text-2xl font-semibold">Sign Up</h2>
-      <input
-        type="text"
-        className="w-full px-4 py-2 border rounded"
-        placeholder="Your Name"
-        value={userName}
-        onChange={(e) => setUserName(e.target.value)}
-        required
-      />
-      <input
-        type="text"
-        className="w-full px-4 py-2 border rounded"
-        placeholder="Organization Name"
-        value={organizationName}
-        onChange={(e) => setOrganizationName(e.target.value)}
-        required
-      />
-      <input
-        type="text"
-        className="w-full px-4 py-2 border rounded"
-        placeholder="Sector"
-        value={sector}
-        onChange={(e) => setSector(e.target.value)}
-        required
-      />
-      <input
-        type="email"
-        className="w-full px-4 py-2 border rounded"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        required
-      />
-      <input
-        type="text"
-        className="w-full px-4 py-2 border rounded"
-        placeholder="Phone"
-        value={phone}
-        onChange={(e) => setPhone(e.target.value)}
-      />
-      <input
-        type="password"
-        className="w-full px-4 py-2 border rounded"
-        placeholder="Password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        required
-      />
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      <button
-        type="submit"
-        className="bg-primary text-white w-full py-2 rounded hover:bg-primary/90"
-      >
-        {loading ? 'Signing up...' : 'Sign Up'}
-      </button>
-      <p className="text-sm text-center">
-        Already have an account?{' '}
-        <Link href="/" className="text-primary hover:underline">
-          Log in
-        </Link>
-      </p>
-    </form>
+    <div className="grid min-h-screen grid-cols-1 md:grid-cols-2">
+      <div className="hidden md:flex items-center justify-center bg-gray-50">
+        <motion.h2
+          initial={{ opacity: 0, x: -20 }}
+          animate={{ opacity: 1, x: 0 }}
+          className="text-3xl font-semibold"
+        >
+          Create Account
+        </motion.h2>
+      </div>
+      <div className="flex items-center justify-center p-8">
+        <form
+          onSubmit={form.handleSubmit(handleSubmit)}
+          className="w-full max-w-md space-y-4"
+          noValidate
+        >
+          <div>
+            <Label htmlFor="userName">Your Name</Label>
+            <Input id="userName" {...form.register('userName')} />
+            {form.formState.errors.userName && (
+              <p className="mt-1 text-sm text-red-600" role="alert">
+                {form.formState.errors.userName.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="organizationName">Organization Name</Label>
+            <Input id="organizationName" {...form.register('organizationName')} />
+            {form.formState.errors.organizationName && (
+              <p className="mt-1 text-sm text-red-600" role="alert">
+                {form.formState.errors.organizationName.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="sector">Sector</Label>
+            <Input id="sector" {...form.register('sector')} />
+            {form.formState.errors.sector && (
+              <p className="mt-1 text-sm text-red-600" role="alert">
+                {form.formState.errors.sector.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="email">Email</Label>
+            <Input id="email" type="email" autoComplete="email" {...form.register('email')} />
+            {form.formState.errors.email && (
+              <p className="mt-1 text-sm text-red-600" role="alert">
+                {form.formState.errors.email.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="phone">Phone</Label>
+            <Input id="phone" {...form.register('phone')} />
+            {form.formState.errors.phone && (
+              <p className="mt-1 text-sm text-red-600" role="alert">
+                {form.formState.errors.phone.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <Label htmlFor="password">Password</Label>
+            <div className="relative">
+              <Input
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                autoComplete="new-password"
+                {...form.register('password')}
+                onKeyUp={handleCaps}
+                onKeyDown={handleCaps}
+                aria-describedby="caps-lock password-strength"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((p) => !p)}
+                className="absolute inset-y-0 right-0 flex items-center px-3 text-gray-600 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? (
+                  <EyeOffIcon className="h-4 w-4" />
+                ) : (
+                  <EyeIcon className="h-4 w-4" />
+                )}
+              </button>
+            </div>
+            {capsLock && (
+              <p id="caps-lock" className="mt-1 text-xs text-yellow-600" role="alert">
+                Caps lock is on
+              </p>
+            )}
+            <PasswordStrength password={password} />
+            {form.formState.errors.password && (
+              <p className="mt-1 text-sm text-red-600" role="alert">
+                {form.formState.errors.password.message}
+              </p>
+            )}
+          </div>
+          {serverError && (
+            <p className="text-sm text-red-600" role="alert">
+              {serverError}
+            </p>
+          )}
+          <Button type="submit" className="w-full">
+            {form.formState.isSubmitting ? 'Signing up...' : 'Sign Up'}
+          </Button>
+          <p className="text-sm text-center">
+            Already have an account?{' '}
+            <Link href="/" className="text-primary underline-offset-4 hover:underline">
+              Log in
+            </Link>
+          </p>
+        </form>
+      </div>
+    </div>
   );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, ...props }, ref) => {
+  return (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+Button.displayName = 'Button';
+
+export { Button };

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 placeholder-gray-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+Input.displayName = 'Input';
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+    {...props}
+  />
+));
+Label.displayName = 'Label';
+
+export { Label };

--- a/src/components/ui/password-strength.tsx
+++ b/src/components/ui/password-strength.tsx
@@ -1,0 +1,36 @@
+import { useMemo } from 'react';
+import { motion } from 'framer-motion';
+
+interface PasswordStrengthProps {
+  password: string;
+}
+
+function calculateStrength(password: string): number {
+  let score = 0;
+  if (password.length >= 8) score++;
+  if (/[A-Z]/.test(password)) score++;
+  if (/[a-z]/.test(password)) score++;
+  if (/\d/.test(password)) score++;
+  if (/[^A-Za-z0-9]/.test(password)) score++;
+  return Math.min(score, 4);
+}
+
+const colors = ['bg-red-500', 'bg-orange-500', 'bg-yellow-500', 'bg-green-500'];
+const labels = ['Very Weak', 'Weak', 'Fair', 'Strong'];
+
+export function PasswordStrength({ password }: PasswordStrengthProps) {
+  const strength = useMemo(() => calculateStrength(password), [password]);
+  const percent = (strength / 4) * 100;
+  return (
+    <div className="mt-1" aria-live="polite">
+      <div className="h-2 w-full rounded bg-gray-200" aria-hidden="true">
+        <motion.div
+          initial={{ width: 0 }}
+          animate={{ width: `${percent}%` }}
+          className={`h-2 rounded ${colors[strength - 1] || ''}`}
+        />
+      </div>
+      {password && <p className="mt-1 text-xs text-gray-600">Password strength: {labels[strength - 1] || 'Very Weak'}</p>}
+    </div>
+  );
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,5 @@
+import { clsx, type ClassValue } from 'clsx';
+
+export function cn(...inputs: ClassValue[]) {
+  return clsx(inputs);
+}

--- a/src/lib/zodResolver.ts
+++ b/src/lib/zodResolver.ts
@@ -1,0 +1,21 @@
+import type { FieldError } from 'react-hook-form';
+import { z } from 'zod';
+
+export function zodResolver<T extends z.ZodTypeAny>(schema: T) {
+  return async (values: unknown): Promise<{ values: z.infer<T> | {}; errors: Record<string, FieldError> }> => {
+    const result = schema.safeParse(values);
+    if (result.success) {
+      return { values: result.data, errors: {} };
+    }
+
+    const fieldErrors: Record<string, FieldError> = {};
+    result.error.errors.forEach((err) => {
+      const path = err.path[0] as string;
+      if (!fieldErrors[path]) {
+        fieldErrors[path] = { type: err.code, message: err.message };
+      }
+    });
+
+    return { values: {}, errors: fieldErrors };
+  };
+}


### PR DESCRIPTION
## Summary
- replace login and register forms with React Hook Form + Zod validation
- add password strength meter, visibility toggle and caps-lock cues
- introduce shadcn-style form components with accessible focus states

## Testing
- `yarn lint` *(fails: This package doesn't seem to be present in your lockfile)*
- `yarn build` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_689c53c2d7e48329a1411dad6518054a