### PR TITLE
feat: manager dashboard and task details

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,4 +33,30 @@ model Task {
   assignedTo Int
   status     String
   user       User   @relation(fields: [assignedTo], references: [id])
+  attachments Attachment[]
+  comments    Comment[]
+  activities  Activity[]
+}
+
+model Attachment {
+  id     Int   @id @default(autoincrement())
+  name   String
+  data   String
+  taskId Int
+  task   Task  @relation(fields: [taskId], references: [id])
+}
+
+model Comment {
+  id      Int   @id @default(autoincrement())
+  content String
+  taskId  Int
+  task    Task  @relation(fields: [taskId], references: [id])
+}
+
+model Activity {
+  id        Int      @id @default(autoincrement())
+  description String
+  createdAt DateTime @default(now())
+  taskId    Int
+  task      Task     @relation(fields: [taskId], references: [id])
 }

--- a/src/app/api/tasks/[id]/activities/route.ts
+++ b/src/app/api/tasks/[id]/activities/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const taskId = Number(idParam);
+  try {
+    const activities = await prisma.activity.findMany({
+      where: { taskId },
+      orderBy: { createdAt: 'desc' },
+    });
+    return NextResponse.json(activities, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to fetch activities' }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/attachments/route.ts
+++ b/src/app/api/tasks/[id]/attachments/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const taskId = Number(idParam);
+  try {
+    const attachments = await prisma.attachment.findMany({ where: { taskId } });
+    return NextResponse.json(attachments, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to fetch attachments' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const taskId = Number(idParam);
+  const formData = await request.formData();
+  const file = formData.get('file') as File;
+  if (!file) {
+    return NextResponse.json({ error: 'No file uploaded' }, { status: 400 });
+  }
+  try {
+    const bytes = await file.arrayBuffer();
+    const base64 = Buffer.from(bytes).toString('base64');
+    const attachment = await prisma.attachment.create({
+      data: { taskId, name: file.name, data: base64 },
+    });
+    await prisma.activity.create({ data: { taskId, description: `Attachment ${file.name} uploaded` } });
+    return NextResponse.json(attachment, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to upload attachment' }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/comments/route.ts
+++ b/src/app/api/tasks/[id]/comments/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const taskId = Number(idParam);
+  try {
+    const comments = await prisma.comment.findMany({ where: { taskId } });
+    return NextResponse.json(comments, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to fetch comments' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  const { id: idParam } = await params;
+  const taskId = Number(idParam);
+  const data = await request.json();
+  try {
+    const comment = await prisma.comment.create({ data: { taskId, content: data.content } });
+    await prisma.activity.create({ data: { taskId, description: 'Comment added' } });
+    return NextResponse.json(comment, { status: 201 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to add comment' }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -21,9 +21,14 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
   const { id: idParam } = await params;
   const id = Number(idParam);
   const data = await request.json();
-  
+
   try {
     const task = await prisma.task.update({ where: { id }, data });
+    if (data.status) {
+      await prisma.activity.create({
+        data: { taskId: id, description: `Status changed to ${data.status}` },
+      });
+    }
     return NextResponse.json(task, { status: 200 });
   } catch (err) {
     console.error(err);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,10 @@
+import AppLayout from '@/components/layout/AppLayout';
+
+export default function DashboardPage() {
+  return (
+    <AppLayout>
+      <h2 className="text-2xl font-semibold">Dashboard</h2>
+      <p>Welcome to your dashboard.</p>
+    </AppLayout>
+  );
+}

--- a/src/app/manager/page.tsx
+++ b/src/app/manager/page.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import ManagerLayout from '@/components/layout/ManagerLayout';
+import { useTasks, useUpdateTask, useDeleteTask, Task } from '@/lib/hooks/useTasks';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { ErrorState } from '@/components/ui/ErrorState';
+import { SelectFilter } from '@/components/ui/SelectFilter';
+
+export default function ManagerPage() {
+  const { data: tasks, isLoading, isError } = useTasks();
+  const updateTask = useUpdateTask();
+  const deleteTask = useDeleteTask();
+
+  const [view, setView] = useState<'kanban' | 'table'>(() => {
+    if (typeof window !== 'undefined') {
+      return (localStorage.getItem('managerView') as 'kanban' | 'table') || 'kanban';
+    }
+    return 'kanban';
+  });
+
+  const toggleView = (v: 'kanban' | 'table') => {
+    setView(v);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('managerView', v);
+    }
+  };
+
+  const [filterStatus, setFilterStatus] = useState<'all' | 'pending' | 'in-progress' | 'completed'>('all');
+  const [selected, setSelected] = useState<number[]>([]);
+
+  const filteredTasks = useMemo(() => {
+    return tasks?.filter((t) => (filterStatus === 'all' ? true : t.status === filterStatus)) ?? [];
+  }, [tasks, filterStatus]);
+
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>, task: Task) => {
+    e.dataTransfer.setData('taskId', task.id.toString());
+  };
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>, status: Task['status']) => {
+    e.preventDefault();
+    const id = Number(e.dataTransfer.getData('taskId'));
+    const task = tasks?.find((t) => t.id === id);
+    if (task && task.status !== status) {
+      updateTask.mutate({ ...task, status });
+    }
+  };
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+  };
+
+  const handleSelect = (id: number, checked: boolean) => {
+    setSelected((prev) => (checked ? [...prev, id] : prev.filter((s) => s !== id)));
+  };
+
+  const deleteSelected = () => {
+    selected.forEach((id) => deleteTask.mutate(id));
+    setSelected([]);
+  };
+
+  const completeSelected = () => {
+    selected.forEach((id) => {
+      const task = tasks?.find((t) => t.id === id);
+      if (task) {
+        updateTask.mutate({ ...task, status: 'completed' });
+      }
+    });
+    setSelected([]);
+  };
+
+  const statuses: Task['status'][] = ['pending', 'in-progress', 'completed'];
+
+  return (
+    <ManagerLayout>
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex gap-4 items-center">
+          <SelectFilter
+            label="Filter by Status"
+            value={filterStatus}
+            onChange={(val) => setFilterStatus(val)}
+            options={[
+              { label: 'All', value: 'all' },
+              { label: 'Pending', value: 'pending' },
+              { label: 'In Progress', value: 'in-progress' },
+              { label: 'Completed', value: 'completed' },
+            ]}
+          />
+        </div>
+        <div className="flex gap-2">
+          <button
+            onClick={() => toggleView('kanban')}
+            className={`px-3 py-1 rounded border text-sm ${view === 'kanban' ? 'bg-primary text-white' : ''}`}
+          >
+            Kanban
+          </button>
+          <button
+            onClick={() => toggleView('table')}
+            className={`px-3 py-1 rounded border text-sm ${view === 'table' ? 'bg-primary text-white' : ''}`}
+          >
+            Table
+          </button>
+        </div>
+      </div>
+
+      {isLoading && <LoadingSpinner />}
+      {isError && <p className="text-red-500">Failed to load tasks.</p>}
+
+      {!isLoading && filteredTasks.length === 0 && <ErrorState message="No data found" />}
+
+      {view === 'kanban' && filteredTasks.length > 0 && (
+        <div className="flex gap-4">
+          {statuses.map((status) => (
+            <div
+              key={status}
+              className="flex-1 bg-gray-100 p-3 rounded"
+              onDragOver={handleDragOver}
+              onDrop={(e) => handleDrop(e, status)}
+            >
+              <h3 className="capitalize font-medium mb-2">{status}</h3>
+              <div className="space-y-2 min-h-[50px]">
+                {filteredTasks
+                  .filter((t) => t.status === status)
+                  .map((task) => (
+                    <div
+                      key={task.id}
+                      draggable
+                      onDragStart={(e) => handleDragStart(e, task)}
+                      className="p-2 bg-white shadow rounded cursor-move"
+                    >
+                      <Link href={`/tasks/${task.id}`} className="hover:underline">
+                        {task.title}
+                      </Link>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {view === 'table' && filteredTasks.length > 0 && (
+        <div className="rounded overflow-hidden bg-white shadow">
+          {selected.length > 0 && (
+            <div className="p-3 flex gap-2 border-b text-sm">
+              <button onClick={completeSelected} className="px-2 py-1 bg-primary text-white rounded">
+                Mark Completed
+              </button>
+              <button onClick={deleteSelected} className="px-2 py-1 bg-red-500 text-white rounded">
+                Delete Selected
+              </button>
+            </div>
+          )}
+          <table className="w-full text-sm">
+            <thead className="bg-gray-200">
+              <tr>
+                <th className="p-3"></th>
+                <th className="text-left p-3">Title</th>
+                <th className="text-left p-3">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {filteredTasks.map((task) => (
+                <tr key={task.id} className="border-t border-gray-200 hover:bg-gray-50">
+                  <td className="p-3 text-center">
+                    <input
+                      type="checkbox"
+                      checked={selected.includes(task.id)}
+                      onChange={(e) => handleSelect(task.id, e.target.checked)}
+                    />
+                  </td>
+                  <td className="p-3">
+                    <Link href={`/tasks/${task.id}`} className="hover:underline">
+                      {task.title}
+                    </Link>
+                  </td>
+                  <td className="p-3 capitalize">{task.status}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </ManagerLayout>
+  );
+}

--- a/src/app/tasks/[id]/page.tsx
+++ b/src/app/tasks/[id]/page.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import AppLayout from '@/components/layout/AppLayout';
+import {
+  useTaskDetail,
+  useTaskComments,
+  useAddComment,
+  useTaskAttachments,
+  useUploadAttachment,
+  useTaskActivities,
+  Attachment,
+  Comment,
+  Activity,
+} from '@/lib/hooks/useTaskDetail';
+
+export default function TaskDetailPage({ params }: { params: { id: string } }) {
+  const taskId = Number(params.id);
+  const { data: task } = useTaskDetail(taskId);
+  const { data: comments } = useTaskComments(taskId);
+  const { mutate: addComment } = useAddComment(taskId);
+  const { data: attachments } = useTaskAttachments(taskId);
+  const { mutate: uploadAttachment } = useUploadAttachment(taskId);
+  const { data: activities } = useTaskActivities(taskId);
+
+  const [commentText, setCommentText] = useState('');
+
+  const handleCommentSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (commentText.trim()) {
+      addComment(commentText);
+      setCommentText('');
+    }
+  };
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      uploadAttachment(file);
+    }
+  };
+
+  return (
+    <AppLayout>
+      <h2 className="text-2xl font-semibold mb-4">{task?.title}</h2>
+      <p className="mb-6">Status: {task?.status}</p>
+
+      <section className="mb-6">
+        <h3 className="font-medium mb-2">Attachments</h3>
+        <input type="file" onChange={handleFileChange} className="mb-2" />
+        <ul className="list-disc pl-5 space-y-1">
+          {attachments?.map((a: Attachment) => (
+            <li key={a.id}>
+              <a
+                href={`data:application/octet-stream;base64,${a.data}`}
+                download={a.name}
+                className="text-primary hover:underline"
+              >
+                {a.name}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="mb-6">
+        <h3 className="font-medium mb-2">Comments</h3>
+        <form onSubmit={handleCommentSubmit} className="mb-2 flex gap-2">
+          <input
+            type="text"
+            value={commentText}
+            onChange={(e) => setCommentText(e.target.value)}
+            className="flex-1 border px-2 py-1 rounded"
+            placeholder="Add a comment"
+          />
+          <button type="submit" className="px-4 py-1 bg-primary text-white rounded">
+            Add
+          </button>
+        </form>
+        <ul className="list-disc pl-5 space-y-1">
+          {comments?.map((c: Comment) => (
+            <li key={c.id}>{c.content}</li>
+          ))}
+        </ul>
+      </section>
+
+      <section>
+        <h3 className="font-medium mb-2">Activity Log</h3>
+        <ul className="list-disc pl-5 space-y-1">
+          {activities?.map((a: Activity) => (
+            <li key={a.id}>
+              {a.description} - {new Date(a.createdAt).toLocaleString()}
+            </li>
+          ))}
+        </ul>
+      </section>
+    </AppLayout>
+  );
+}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { withAuthGuard } from '@/utils/ProtectedLayout';
+import { Header } from './Header';
+
+function AppLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+      <Header />
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  );
+}
+
+export default withAuthGuard(AppLayout);

--- a/src/components/layout/ManagerLayout.tsx
+++ b/src/components/layout/ManagerLayout.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { withAuthGuard } from '@/utils/ProtectedLayout';
+import { Header } from './Header';
+
+function ManagerLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col min-h-screen bg-gray-50">
+      <Header />
+      <main className="flex-1 p-6">{children}</main>
+    </div>
+  );
+}
+
+export default withAuthGuard(ManagerLayout, ['manager']);

--- a/src/lib/hooks/useTaskDetail.ts
+++ b/src/lib/hooks/useTaskDetail.ts
@@ -1,0 +1,77 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetcher } from '../api/fetcher';
+
+export interface Attachment {
+  id: number;
+  name: string;
+  data: string;
+}
+
+export interface Comment {
+  id: number;
+  content: string;
+}
+
+export interface Activity {
+  id: number;
+  description: string;
+  createdAt: string;
+}
+
+export const useTaskDetail = (id: number) =>
+  useQuery({
+    queryKey: ['task', id],
+    queryFn: async () => (await fetcher.get(`/tasks/${id}`)).data,
+    enabled: !!id,
+  });
+
+export const useTaskComments = (id: number) =>
+  useQuery({
+    queryKey: ['task', id, 'comments'],
+    queryFn: async () => (await fetcher.get(`/tasks/${id}/comments`)).data,
+    enabled: !!id,
+  });
+
+export const useAddComment = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (content: string) => {
+      await fetcher.post(`/tasks/${id}/comments`, { content });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['task', id, 'comments'] });
+      queryClient.invalidateQueries({ queryKey: ['task', id, 'activities'] });
+    },
+  });
+};
+
+export const useTaskAttachments = (id: number) =>
+  useQuery({
+    queryKey: ['task', id, 'attachments'],
+    queryFn: async () => (await fetcher.get(`/tasks/${id}/attachments`)).data,
+    enabled: !!id,
+  });
+
+export const useUploadAttachment = (id: number) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (file: File) => {
+      const formData = new FormData();
+      formData.append('file', file);
+      await fetcher.post(`/tasks/${id}/attachments`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['task', id, 'attachments'] });
+      queryClient.invalidateQueries({ queryKey: ['task', id, 'activities'] });
+    },
+  });
+};
+
+export const useTaskActivities = (id: number) =>
+  useQuery({
+    queryKey: ['task', id, 'activities'],
+    queryFn: async () => (await fetcher.get(`/tasks/${id}/activities`)).data,
+    enabled: !!id,
+  });


### PR DESCRIPTION
## Summary
- add role-guarded App and Manager layouts with new dashboard and manager pages
- implement kanban/table manager view with drag & drop, filters, and bulk actions
- add task detail view with attachments, comments, and activity log plus supporting APIs

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_e_689c53c56bbc83298929915ff9381073