### PR TITLE
Add toast provider with duplicate key tracking

### DIFF
--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -2,6 +2,7 @@
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState } from 'react';
+import { ToastProvider } from '@/components/ui/ToastProvider';
 
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -10,6 +11,7 @@ export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <QueryClientProvider client={queryClient}>
       {children}
+      <ToastProvider />
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/src/components/ui/ToastProvider.tsx
+++ b/src/components/ui/ToastProvider.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+import { Toaster, toast as baseToast } from 'sonner';
+import { useToastStore } from '@/lib/store/useToastStore';
+
+interface ToastOptions {
+  id?: string;
+  onDismiss?: (toastId: string | number) => void;
+  [key: string]: unknown;
+}
+
+export const toast = (
+  message: ReactNode,
+  options: ToastOptions = {},
+) => {
+  const key = options.id;
+  const { has, add, remove } = useToastStore.getState();
+  if (key && has(key)) return;
+  if (key) add(key);
+  baseToast(message, {
+    ...options,
+    id: key,
+    onDismiss: (t: unknown) => {
+      options.onDismiss?.(t);
+      if (key) remove(key);
+    },
+  });
+};
+
+export function ToastProvider() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia('(max-width: 640px)');
+    const handler = (e: MediaQueryListEvent | MediaQueryList) => {
+      setIsMobile(e.matches);
+    };
+    handler(mq);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+
+  return <Toaster position={isMobile ? 'bottom-center' : 'top-center'} />;
+}

--- a/src/lib/store/useToastStore.ts
+++ b/src/lib/store/useToastStore.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+
+interface ToastState {
+  active: string[];
+  add: (key: string) => void;
+  remove: (key: string) => void;
+  has: (key: string) => boolean;
+}
+
+export const useToastStore = create<ToastState>((set, get) => ({
+  active: [],
+  add: (key) =>
+    set((state) => ({ active: [...state.active, key] })),
+  remove: (key) =>
+    set((state) => ({ active: state.active.filter((k) => k !== key) })),
+  has: (key) => get().active.includes(key),
+}));


### PR DESCRIPTION
## Summary
- add ToastProvider with responsive placement and duplicate suppression
- track active toast IDs in a zustand store
- include provider in root Providers component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c53c578908329af7e513e3f080963