### PR TITLE
feat: add rate limiting and input validation

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -2,22 +2,26 @@ import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { checkRateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { loginSchema } from '@/lib/validators';
 
 export async function POST(request: Request) {
   try {
-    const { email = '', password = '' } = await request.json();
-    const normalisedEmail = email.trim().toLowerCase();
-
-    if (!normalisedEmail || !password) {
-      return NextResponse.json(
-        { error: 'Email and password are required' },
-        { status: 400 }
-      );
+    if (!checkRateLimit(request)) {
+      return rateLimitResponse();
     }
+
+    const body = await request.json();
+    const parsed = loginSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+    }
+
+    const { email, password } = parsed.data;
 
     // 2️⃣ Explicitly fetch the hashed password
     const user = await prisma.user.findUnique({
-      where: { email: normalisedEmail },
+      where: { email },
       select: { id: true, email: true, role: true, password: true, organizationId: true },
     });
 

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -1,10 +1,17 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { checkRateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { taskUpdateSchema } from '@/lib/validators';
+import { z } from 'zod';
 
 export async function GET(request: Request, { params }: { params: Promise<{ id: string }> }) {
   const { id: idParam } = await params;
-  const id = Number(idParam);
-  
+  const idResult = z.coerce.number().int().safeParse(idParam);
+  if (!idResult.success) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+  const id = idResult.data;
+
   try {
     const task = await prisma.task.findUnique({ where: { id } });
     if (!task) {
@@ -18,12 +25,23 @@ export async function GET(request: Request, { params }: { params: Promise<{ id: 
 }
 
 export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!checkRateLimit(request)) {
+    return rateLimitResponse();
+  }
   const { id: idParam } = await params;
-  const id = Number(idParam);
-  const data = await request.json();
-  
+  const idResult = z.coerce.number().int().safeParse(idParam);
+  if (!idResult.success) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+  const id = idResult.data;
+  const body = await request.json();
+  const parsed = taskUpdateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+  }
+
   try {
-    const task = await prisma.task.update({ where: { id }, data });
+    const task = await prisma.task.update({ where: { id }, data: parsed.data });
     return NextResponse.json(task, { status: 200 });
   } catch (err) {
     console.error(err);
@@ -32,9 +50,16 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
 }
 
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!checkRateLimit(request)) {
+    return rateLimitResponse();
+  }
   const { id: idParam } = await params;
-  const id = Number(idParam);
-  
+  const idResult = z.coerce.number().int().safeParse(idParam);
+  if (!idResult.success) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+  const id = idResult.data;
+
   try {
     await prisma.task.delete({ where: { id } });
     return NextResponse.json({ message: 'Task deleted' }, { status: 200 });

--- a/src/app/api/tasks/route.ts
+++ b/src/app/api/tasks/route.ts
@@ -1,11 +1,21 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { checkRateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { taskCreateSchema } from '@/lib/validators';
+import { z } from 'zod';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const organizationId = searchParams.get('organizationId')
-    ? Number(searchParams.get('organizationId'))
-    : undefined;
+  const querySchema = z.object({
+    organizationId: z.coerce.number().int().optional(),
+  });
+  const parsed = querySchema.safeParse({
+    organizationId: searchParams.get('organizationId') ?? undefined,
+  });
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid query' }, { status: 400 });
+  }
+  const { organizationId } = parsed.data;
 
   try {
     const tasks = await prisma.task.findMany({
@@ -22,8 +32,16 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const data = await request.json();
-    const task = await prisma.task.create({ data });
+    if (!checkRateLimit(request)) {
+      return rateLimitResponse();
+    }
+
+    const body = await request.json();
+    const parsed = taskCreateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+    }
+    const task = await prisma.task.create({ data: parsed.data });
     return NextResponse.json(task, { status: 201 });
   } catch (err) {
     console.error(err);

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,11 +1,26 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
+import { checkRateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { userUpdateSchema } from '@/lib/validators';
+import { z } from 'zod';
 
 export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!checkRateLimit(request)) {
+    return rateLimitResponse();
+  }
   const { id: idParam } = await params;
-  const id = Number(idParam);
-  const data = await request.json();
+  const idResult = z.coerce.number().int().safeParse(idParam);
+  if (!idResult.success) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+  const id = idResult.data;
+  const body = await request.json();
+  const parsed = userUpdateSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+  }
+  const data = parsed.data;
 
   if (data.password) {
     data.password = await bcrypt.hash(data.password, 10);
@@ -31,8 +46,15 @@ export async function PATCH(request: Request, { params }: { params: Promise<{ id
 }
 
 export async function DELETE(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  if (!checkRateLimit(request)) {
+    return rateLimitResponse();
+  }
   const { id: idParam } = await params;
-  const id = Number(idParam);
+  const idResult = z.coerce.number().int().safeParse(idParam);
+  if (!idResult.success) {
+    return NextResponse.json({ error: 'Invalid id' }, { status: 400 });
+  }
+  const id = idResult.data;
 
   try {
     await prisma.user.delete({ where: { id } });

--- a/src/app/api/users/login/route.ts
+++ b/src/app/api/users/login/route.ts
@@ -1,17 +1,22 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
+import { checkRateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { loginSchema } from '@/lib/validators';
 
 export async function POST(request: Request) {
   try {
-    const { email, password } = await request.json();
-
-    if (!email || !password) {
-      return NextResponse.json(
-        { error: 'Email and password are required' },
-        { status: 400 }
-      );
+    if (!checkRateLimit(request)) {
+      return rateLimitResponse();
     }
+
+    const body = await request.json();
+    const parsed = loginSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
+    }
+
+    const { email, password } = parsed.data;
 
     const user = await prisma.user.findUnique({
       where: { email },

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,16 +1,24 @@
 import { NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
 import bcrypt from 'bcrypt';
-
-const ROLES = ['admin', 'manager', 'user'] as const;
-// type Role = typeof ROLES[number];
+import { checkRateLimit, rateLimitResponse } from '@/lib/rateLimit';
+import { userCreateSchema } from '@/lib/validators';
+import { z } from 'zod';
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
-  const email = searchParams.get('email') ?? undefined;
-  const organizationId = searchParams.get('organizationId')
-    ? Number(searchParams.get('organizationId'))
-    : undefined;
+  const querySchema = z.object({
+    email: z.string().email().optional(),
+    organizationId: z.coerce.number().int().optional(),
+  });
+  const parsed = querySchema.safeParse({
+    email: searchParams.get('email') ?? undefined,
+    organizationId: searchParams.get('organizationId') ?? undefined,
+  });
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid query' }, { status: 400 });
+  }
+  const { email, organizationId } = parsed.data;
 
   try {
     const users = await prisma.user.findMany({
@@ -39,34 +47,23 @@ export async function GET(request: Request) {
 
 export async function POST(request: Request) {
   try {
-    const data = await request.json();
-
-    // Basic validation
-    const { name, email, role, password, organizationId } = data;
-
-    if (!name || !email || !role || !organizationId) {
-      return NextResponse.json(
-        { error: 'Name, email, role, and organizationId are required' },
-        { status: 400 }
-      );
+    if (!checkRateLimit(request)) {
+      return rateLimitResponse();
     }
 
-    if (!ROLES.includes(role)) {
-      return NextResponse.json(
-        { error: `Role must be one of: ${ROLES.join(', ')}` },
-        { status: 400 }
-      );
+    const body = await request.json();
+    const parsed = userCreateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'Invalid input' }, { status: 400 });
     }
 
+    const { password, ...rest } = parsed.data;
     const hashedPassword = password ? await bcrypt.hash(password, 10) : undefined;
 
     const user = await prisma.user.create({
       data: {
-        name,
-        email,
-        role,
-        password: hashedPassword, // optional
-        organizationId,
+        ...rest,
+        password: hashedPassword,
       },
       select: {
         id: true,

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+const windowMs = 60 * 1000; // 1 minute
+const limit = 10; // default limit per window
+
+const store = new Map<string, { count: number; expires: number }>();
+
+export function checkRateLimit(request: Request, routeOverride?: string) {
+  const ip =
+    request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+    request.headers.get('x-real-ip') ||
+    'unknown';
+  const route = routeOverride ?? new URL(request.url).pathname;
+  const key = `${ip}:${route}`;
+  const now = Date.now();
+  const entry = store.get(key);
+  if (!entry || entry.expires < now) {
+    store.set(key, { count: 1, expires: now + windowMs });
+    return true;
+  }
+  if (entry.count >= limit) {
+    return false;
+  }
+  entry.count += 1;
+  return true;
+}
+
+export function rateLimitResponse() {
+  return NextResponse.json({ error: 'Too many requests' }, { status: 429 });
+}

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  email: z.string().email().transform((v) => v.trim().toLowerCase()),
+  password: z.string().min(1),
+});
+
+export const taskCreateSchema = z.object({
+  title: z.string().min(1),
+  assignedTo: z.number().int(),
+  status: z.string().min(1),
+});
+
+export const taskUpdateSchema = taskCreateSchema.partial();
+
+const roles = ['admin', 'manager', 'user'] as const;
+
+export const userCreateSchema = z.object({
+  name: z.string().min(1),
+  email: z.string().email(),
+  role: z.enum(roles),
+  password: z.string().min(1).optional(),
+  organizationId: z.number().int(),
+});
+
+export const userUpdateSchema = userCreateSchema.partial();


### PR DESCRIPTION
## Summary
- add in-memory rate limiter keyed by IP and route
- validate login, task, and user APIs with zod before database calls
- return 429 for throttled requests and 400 for invalid payloads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c53c686e4832989b8d74f854398a5