### PR TITLE
feat: add OTP verification flow

### DIFF
--- a/src/app/api/auth/otpStore.ts
+++ b/src/app/api/auth/otpStore.ts
@@ -1,0 +1,33 @@
+interface OTPEntry {
+  code: string;
+  expires: number;
+  attempts: number;
+}
+
+export const otpStore = new Map<string, OTPEntry>();
+
+interface RateLimitEntry {
+  count: number;
+  timestamp: number;
+}
+
+export const requestRateMap = new Map<string, RateLimitEntry>();
+export const verifyRateMap = new Map<string, RateLimitEntry>();
+
+export function isRateLimited(
+  map: Map<string, RateLimitEntry>,
+  key: string,
+  limit: number,
+  windowMs: number
+): boolean {
+  const now = Date.now();
+  const entry = map.get(key);
+  if (entry && now - entry.timestamp < windowMs) {
+    if (entry.count >= limit) return true;
+    entry.count += 1;
+    map.set(key, entry);
+    return false;
+  }
+  map.set(key, { count: 1, timestamp: now });
+  return false;
+}

--- a/src/app/api/auth/request-otp/route.ts
+++ b/src/app/api/auth/request-otp/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+import { otpStore, requestRateMap, isRateLimited } from '../otpStore';
+
+const REQUEST_LIMIT = 5;
+const WINDOW_MS = 60 * 1000; // 1 minute
+
+export async function POST(request: Request) {
+  try {
+    const { email = '' } = await request.json();
+    const normalisedEmail = email.trim().toLowerCase();
+
+    if (!normalisedEmail) {
+      return NextResponse.json(
+        { error: 'Email is required' },
+        { status: 400 }
+      );
+    }
+
+    if (isRateLimited(requestRateMap, normalisedEmail, REQUEST_LIMIT, WINDOW_MS)) {
+      return NextResponse.json(
+        { error: 'Too many requests' },
+        { status: 429 }
+      );
+    }
+
+    const code = String(Math.floor(100000 + Math.random() * 900000));
+    otpStore.set(normalisedEmail, {
+      code,
+      expires: Date.now() + 5 * 60 * 1000,
+      attempts: 0,
+    });
+
+    console.log(`OTP for ${normalisedEmail}: ${code}`);
+
+    return NextResponse.json({ success: true }, { status: 200 });
+  } catch (err) {
+    console.error('REQUEST_OTP_ERROR', err);
+    return NextResponse.json(
+      { error: 'Failed to request OTP' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+import jwt from 'jsonwebtoken';
+import { otpStore, verifyRateMap, isRateLimited } from '../otpStore';
+
+const VERIFY_LIMIT = 5;
+const WINDOW_MS = 60 * 1000; // 1 minute
+
+export async function POST(request: Request) {
+  try {
+    const { email = '', otp = '' } = await request.json();
+    const normalisedEmail = email.trim().toLowerCase();
+
+    if (!normalisedEmail || !otp) {
+      return NextResponse.json(
+        { error: 'Email and OTP are required' },
+        { status: 400 }
+      );
+    }
+
+    if (isRateLimited(verifyRateMap, normalisedEmail, VERIFY_LIMIT, WINDOW_MS)) {
+      return NextResponse.json(
+        { error: 'Too many attempts' },
+        { status: 429 }
+      );
+    }
+
+    const record = otpStore.get(normalisedEmail);
+    if (!record || record.expires < Date.now() || record.code !== otp) {
+      return NextResponse.json(
+        { error: 'Invalid or expired OTP' },
+        { status: 400 }
+      );
+    }
+
+    otpStore.delete(normalisedEmail);
+
+    const user = await prisma.user.findUnique({
+      where: { email: normalisedEmail },
+      select: {
+        id: true,
+        name: true,
+        email: true,
+        role: true,
+        organizationId: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    }
+
+    const jwtSecret = process.env.JWT_SECRET;
+    if (!jwtSecret) {
+      console.error('JWT_SECRET is not set');
+      return NextResponse.json(
+        { error: 'JWT secret not configured' },
+        { status: 500 }
+      );
+    }
+
+    const token = jwt.sign(
+      {
+        id: user.id,
+        email: user.email,
+        role: user.role,
+        organizationId: user.organizationId,
+        mfa: true,
+      },
+      jwtSecret,
+      { expiresIn: '1h' }
+    );
+
+    return NextResponse.json({ user, token }, { status: 200 });
+  } catch (err) {
+    console.error('VERIFY_OTP_ERROR', err);
+    return NextResponse.json(
+      { error: 'Failed to verify OTP' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/verify-otp/page.tsx
+++ b/src/app/verify-otp/page.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { useRequestOTP } from '@/lib/hooks/useRequestOTP';
+import { useVerifyOTP } from '@/lib/hooks/useVerifyOTP';
+
+export default function VerifyOTPPage() {
+  const router = useRouter();
+  const { requestOTP } = useRequestOTP();
+  const { verifyOTP } = useVerifyOTP();
+  const [email, setEmail] = useState('');
+  const [otp, setOtp] = useState('');
+  const [requested, setRequested] = useState(false);
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleRequest = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await requestOTP(email);
+      setRequested(true);
+    } catch {
+      setError('Failed to request OTP');
+    }
+  };
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+    try {
+      const { user } = await verifyOTP(email, otp);
+      if (user.role === 'admin') {
+        router.push('/admin');
+      } else if (user.role === 'manager') {
+        router.push('/manager');
+      } else {
+        router.push('/dashboard');
+      }
+    } catch {
+      setError('Invalid OTP');
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-sm mx-auto mt-10 space-y-4">
+      <h2 className="text-2xl font-semibold">Verify OTP</h2>
+      {!requested ? (
+        <form onSubmit={handleRequest} className="space-y-4">
+          <input
+            type="email"
+            className="w-full px-4 py-2 border rounded"
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <button
+            type="submit"
+            className="bg-primary text-white w-full py-2 rounded hover:bg-primary/90"
+          >
+            Request OTP
+          </button>
+          <p className="text-sm text-center">
+            Back to{' '}
+            <Link href="/" className="text-primary hover:underline">
+              Log in
+            </Link>
+          </p>
+        </form>
+      ) : (
+        <form onSubmit={handleVerify} className="space-y-4">
+          <input
+            type="text"
+            className="w-full px-4 py-2 border rounded"
+            placeholder="One-Time Password"
+            value={otp}
+            onChange={(e) => setOtp(e.target.value)}
+            required
+          />
+          {error && <p className="text-red-500 text-sm">{error}</p>}
+          <button
+            type="submit"
+            className="bg-primary text-white w-full py-2 rounded hover:bg-primary/90"
+          >
+            {loading ? 'Verifying...' : 'Verify OTP'}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/lib/hooks/useRequestOTP.ts
+++ b/src/lib/hooks/useRequestOTP.ts
@@ -1,0 +1,10 @@
+import axios from 'axios';
+
+export const useRequestOTP = () => {
+  const requestOTP = async (email: string) => {
+    const { data } = await axios.post('/api/auth/request-otp', { email });
+    return data;
+  };
+
+  return { requestOTP };
+};

--- a/src/lib/hooks/useVerifyOTP.ts
+++ b/src/lib/hooks/useVerifyOTP.ts
@@ -1,0 +1,32 @@
+import axios from 'axios';
+import { useAuthStore } from '@/lib/store/useAuthStore';
+import type { Role } from '@/lib/store/useAuthStore';
+
+interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: Role;
+  organizationId: number;
+}
+
+interface VerifyResponse {
+  user: User;
+  token: string;
+}
+
+export const useVerifyOTP = () => {
+  const authLogin = useAuthStore((state) => state.login);
+
+  const verifyOTP = async (email: string, otp: string) => {
+    const { data } = await axios.post<VerifyResponse>('/api/auth/verify-otp', {
+      email,
+      otp,
+    });
+
+    authLogin(data.user, data.token);
+    return data;
+  };
+
+  return { verifyOTP };
+};


### PR DESCRIPTION
## Summary
- add in-memory OTP store with rate limiting helpers
- implement request and verify OTP API routes issuing step-up JWTs
- provide React hooks and verification page for OTP flow

## Testing
- `yarn lint` *(fails: Internal Error: package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*
- `yarn install` *(fails: RequestError: Bad response: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689c53c7a49c8329827f0f11f51dd2c4