### PR TITLE
Add task activity logging and feed

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,5 +32,17 @@ model Task {
   title      String
   assignedTo Int
   status     String
+  priority   String @default("medium")
   user       User   @relation(fields: [assignedTo], references: [id])
+  activityLogs ActivityLog[]
+}
+
+model ActivityLog {
+  id        Int      @id @default(autoincrement())
+  task      Task     @relation(fields: [taskId], references: [id])
+  taskId    Int
+  field     String
+  oldValue  String?
+  newValue  String?
+  createdAt DateTime @default(now())
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -15,6 +15,10 @@ const generateStatus = () => {
   const statuses = ['pending', 'in-progress', 'completed'];
   return statuses[randomInt(0, statuses.length - 1)];
 };
+const generatePriority = () => {
+  const priorities = ['low', 'medium', 'high'];
+  return priorities[randomInt(0, priorities.length - 1)];
+};
 
 async function main() {
   if (process.env.NODE_ENV === 'production') {
@@ -96,6 +100,7 @@ async function main() {
   const taskData = Array.from({ length: totalTasks }).map((_, i) => ({
     title: `Task ${i + 1}`,
     status: generateStatus(),
+    priority: generatePriority(),
     assignedTo: allUsers[randomInt(0, allUsers.length - 1)].id,
   }));
 

--- a/src/app/admin/tasks/[id]/page.tsx
+++ b/src/app/admin/tasks/[id]/page.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import { useState } from 'react';
+import AdminLayout from '@/components/layout/AdminLayout';
+import { useTask, useTaskActivity } from '@/lib/hooks/useTasks';
+import { useUsers } from '@/lib/hooks/useUsers';
+import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+
+export default function TaskDetailPage() {
+  const params = useParams<{ id: string }>();
+  const taskId = Number(params.id);
+  const { data: task, isLoading, isError } = useTask(taskId);
+  const { data: users } = useUsers();
+  const [page, setPage] = useState(1);
+  const { data: activity } = useTaskActivity(taskId, page);
+
+  const getAssigneeName = (id: number | undefined) =>
+    users?.find((u) => Number(u.id) === Number(id))?.name ?? 'Unknown';
+
+  if (isLoading) {
+    return (
+      <AdminLayout>
+        <LoadingSpinner />
+      </AdminLayout>
+    );
+  }
+
+  if (isError || !task) {
+    return (
+      <AdminLayout>
+        <p className="text-red-500">Task not found</p>
+      </AdminLayout>
+    );
+  }
+
+  const totalPages = activity ? Math.ceil(activity.total / activity.limit) : 1;
+
+  return (
+    <AdminLayout>
+      <h2 className="text-2xl font-semibold mb-4">{task.title}</h2>
+      <div className="mb-6 text-sm">
+        <p><strong>Assigned To:</strong> {getAssigneeName(task.assignedTo)}</p>
+        <p><strong>Status:</strong> {task.status}</p>
+        <p><strong>Priority:</strong> {task.priority}</p>
+      </div>
+      <h3 className="text-xl font-semibold mb-2">Activity</h3>
+      {activity && activity.data.length > 0 ? (
+        <div>
+          <ul className="mb-4">
+            {activity.data.map((log) => (
+              <li key={log.id} className="border-b py-2 text-sm">
+                <span className="font-medium capitalize">{log.field}</span> changed from {log.oldValue ?? '-'} to {log.newValue ?? '-'} on {new Date(log.createdAt).toLocaleString()}
+              </li>
+            ))}
+          </ul>
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between text-sm">
+              <button
+                onClick={() => setPage((p) => Math.max(p - 1, 1))}
+                disabled={page === 1}
+                className="px-3 py-1 rounded border disabled:opacity-50"
+              >
+                Previous
+              </button>
+              <span>
+                Page {page} of {totalPages}
+              </span>
+              <button
+                onClick={() => setPage((p) => Math.min(p + 1, totalPages))}
+                disabled={page === totalPages}
+                className="px-3 py-1 rounded border disabled:opacity-50"
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </div>
+      ) : (
+        <p className="text-sm text-gray-500">No activity yet.</p>
+      )}
+    </AdminLayout>
+  );
+}

--- a/src/app/admin/tasks/page.tsx
+++ b/src/app/admin/tasks/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useTasks, useCreateTask, useUpdateTask, useDeleteTask, Task } from '@/lib/hooks/useTasks';
 import { useUsers } from '@/lib/hooks/useUsers';
 import { TaskModal } from '@/components/modals/TaskModals';
@@ -110,7 +111,11 @@ export default function AdminTasksPage() {
                         <tbody>
                             {paginatedTasks.map((task) => (
                                 <tr key={task.id} className="border-t border-gray-200 hover:bg-gray-50">
-                                    <td className="p-3">{task.title}</td>
+                                    <td className="p-3">
+                                        <Link href={`/admin/tasks/${task.id}`} className="text-primary hover:underline">
+                                            {task.title}
+                                        </Link>
+                                    </td>
                                     <td className="p-3">{getAssigneeName(task.assignedTo)}</td>
                                     <td className="p-3 capitalize">
                                         <span className="px-2 py-1 rounded-full text-xs font-medium border border-gray-300">

--- a/src/app/api/tasks/[id]/activity/route.ts
+++ b/src/app/api/tasks/[id]/activity/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function GET(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id: idParam } = await params;
+  const taskId = Number(idParam);
+  const { searchParams } = new URL(request.url);
+  const page = Number(searchParams.get('page') ?? '1');
+  const limit = Number(searchParams.get('limit') ?? '10');
+  const skip = (page - 1) * limit;
+
+  try {
+    const [data, total] = await Promise.all([
+      prisma.activityLog.findMany({
+        where: { taskId },
+        orderBy: { createdAt: 'desc' },
+        skip,
+        take: limit,
+      }),
+      prisma.activityLog.count({ where: { taskId } }),
+    ]);
+
+    return NextResponse.json({ data, page, limit, total }, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json({ error: 'Failed to fetch activity logs' }, { status: 500 });
+  }
+}

--- a/src/app/api/tasks/[id]/route.ts
+++ b/src/app/api/tasks/[id]/route.ts
@@ -21,9 +21,60 @@ export async function PUT(request: Request, { params }: { params: Promise<{ id: 
   const { id: idParam } = await params;
   const id = Number(idParam);
   const data = await request.json();
-  
+
   try {
+    const existingTask = await prisma.task.findUnique({ where: { id } });
     const task = await prisma.task.update({ where: { id }, data });
+
+    if (existingTask) {
+      const logs = [] as {
+        taskId: number;
+        field: string;
+        oldValue: string | null;
+        newValue: string | null;
+      }[];
+
+      if (
+        data.status &&
+        data.status !== existingTask.status
+      ) {
+        logs.push({
+          taskId: id,
+          field: 'status',
+          oldValue: existingTask.status,
+          newValue: data.status,
+        });
+      }
+
+      if (
+        data.assignedTo &&
+        data.assignedTo !== existingTask.assignedTo
+      ) {
+        logs.push({
+          taskId: id,
+          field: 'assignee',
+          oldValue: String(existingTask.assignedTo),
+          newValue: String(data.assignedTo),
+        });
+      }
+
+      if (
+        data.priority &&
+        data.priority !== existingTask.priority
+      ) {
+        logs.push({
+          taskId: id,
+          field: 'priority',
+          oldValue: existingTask.priority,
+          newValue: data.priority,
+        });
+      }
+
+      if (logs.length > 0) {
+        await prisma.activityLog.createMany({ data: logs });
+      }
+    }
+
     return NextResponse.json(task, { status: 200 });
   } catch (err) {
     console.error(err);

--- a/src/components/modals/TaskModals.tsx
+++ b/src/components/modals/TaskModals.tsx
@@ -15,12 +15,14 @@ export function TaskModal({ isOpen, onClose, onSave, users, initialData = {} }: 
     const [title, setTitle] = useState('');
     const [assignedTo, setAssignedTo] = useState<number | ''>('');
     const [status, setStatus] = useState<'pending' | 'in-progress' | 'completed'>('pending');
+    const [priority, setPriority] = useState<'low' | 'medium' | 'high'>('medium');
 
     useEffect(() => {
         if (initialData) {
             setTitle(initialData.title ?? '');
             setAssignedTo(initialData.assignedTo ?? '');
             setStatus(initialData.status ?? 'pending');
+            setPriority(initialData.priority ?? 'medium');
         }
     }, [initialData]);
 
@@ -63,6 +65,17 @@ export function TaskModal({ isOpen, onClose, onSave, users, initialData = {} }: 
                     <option value="completed">Completed</option>
                 </select>
 
+                <label className="block text-sm font-medium mb-1">Priority</label>
+                <select
+                    value={priority}
+                    onChange={(e) => setPriority(e.target.value as typeof priority)}
+                    className="w-full border px-3 py-2 mb-3 rounded"
+                >
+                    <option value="low">Low</option>
+                    <option value="medium">Medium</option>
+                    <option value="high">High</option>
+                </select>
+
                 <div className="flex justify-end gap-3 mt-4">
                     <button
                         type="button"
@@ -78,6 +91,7 @@ export function TaskModal({ isOpen, onClose, onSave, users, initialData = {} }: 
                                 title,
                                 assignedTo: Number(assignedTo),
                                 status,
+                                priority,
                             })
                         }
                         className="text-sm text-white bg-primary hover:bg-primary/90 px-4 py-2 rounded"

--- a/src/lib/hooks/useTasks.ts
+++ b/src/lib/hooks/useTasks.ts
@@ -7,6 +7,16 @@ export interface Task {
   title: string;
   assignedTo: number;
   status: 'pending' | 'in-progress' | 'completed';
+  priority: 'low' | 'medium' | 'high';
+}
+
+export interface ActivityLog {
+  id: number;
+  taskId: number;
+  field: string;
+  oldValue: string | null;
+  newValue: string | null;
+  createdAt: string;
 }
 
 export const useTasks = () => {
@@ -57,5 +67,29 @@ export const useUpdateTask = () => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['tasks'] });
     },
+  });
+};
+
+export const useTask = (id: number) => {
+  return useQuery<Task>({
+    queryKey: ['task', id],
+    queryFn: async () => {
+      const response = await fetcher.get(`/tasks/${id}`);
+      return response.data;
+    },
+    enabled: !!id,
+  });
+};
+
+export const useTaskActivity = (taskId: number, page = 1) => {
+  return useQuery<{ data: ActivityLog[]; page: number; limit: number; total: number }>({
+    queryKey: ['task', taskId, 'activity', page],
+    queryFn: async () => {
+      const response = await fetcher.get(`/tasks/${taskId}/activity`, {
+        params: { page },
+      });
+      return response.data;
+    },
+    enabled: !!taskId,
   });
 };


### PR DESCRIPTION
## Summary
- track task status, assignee, and priority changes with ActivityLog entries
- expose `/api/tasks/:id/activity` for paginated activity retrieval
- add priority support, task detail page, and UI to display activity feed

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c53c8941c8329b58874c497e6a162